### PR TITLE
fix: improve household and session management

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -16,20 +16,20 @@ Em-Social enables you to maintain detailed records of households, schedule and t
     - [Delete a household](#delete-a-household)
     - [List all households](#list-all-households)
     - [Find households](#find-households)
-    - [Tag households](#tag-households)
   - [Session Management](#session-management)
     - [Add a session](#add-a-session)
     - [Edit a session](#edit-a-session)
     - [Delete a session](#delete-a-session)
-    - [Add a note to a session](#add-a-note-to-a-session)
     - [List sessions](#list-sessions)
   - [User Interface Navigation](#user-interface-navigation)
     - [Household panel](#household-panel)
     - [Session panel](#session-panel)
     - [Command box](#command-box)
     - [Result display](#result-display)
-  - [Help](#help)
-  - [Exiting the program](#exiting-the-program)
+  - [General Commands](#general-commands)
+    - [Clear data](#clear-data)
+    - [Help](#help)
+    - [Exiting the program](#exiting-the-program)
   - [Saving the data](#saving-the-data)
   - [Command summary](#command-summary)
 
@@ -138,23 +138,6 @@ Expected outcome:
 2. Lee Family (ID: H000002)
 ```
 
-### Tag households
-You can add tags to a household with the `tag-household` command.
-```
-tag-household ID t/TAG [t/MORE_TAGS]...
-```
-
-Example of usage:
-```
-tag-household H000003 t/elderly t/medical
-```
-
-Expected outcome:
-```
-Tagged household: Wong Family (ID: H000003)
-Tags: [elderly][medical]
-```
-
 ## Session Management
 Sessions represent scheduled visits to households.
 
@@ -177,32 +160,45 @@ Time: 14:30
 ```
 
 ### Edit a session
-You can modify a session with the `edit-session` command.
+You can modify a session with the `edit-session` command. This command also allows you to add or update a note at the same time.
 ```
-edit-session INDEX d/DATE t/TIME
-```
-
-Example of usage:
-```
-edit-session 1 d/2025-03-16 t/15:00
+edit-session id/HOUSEHOLD_ID-SESSION_INDEX d/DATE t/TIME [n/NOTE]
 ```
 
-Expected outcome:
+Example of usage (without note):
+```
+edit-session id/H000003-1 d/2025-03-16 t/15:00
+```
+
+Example of usage (with note):
+```
+edit-session id/H000003-1 d/2025-03-16 t/15:00 n/Follow-up on medical assistance application
+```
+
+Expected outcome (without note):
 ```
 Edited session:
 Date: 2025-03-16
 Time: 15:00
 ```
 
+Expected outcome (with note):
+```
+Edited session:
+Date: 2025-03-16
+Time: 15:00
+Note: Follow-up on medical assistance application
+```
+
 ### Delete a session
 You can remove a session with the `delete-session` command.
 ```
-delete-session INDEX
+delete-session id/HOUSEHOLD_ID-SESSION_INDEX
 ```
 
 Example of usage:
 ```
-delete-session 1
+delete-session id/H000003-1
 ```
 
 Expected outcome:
@@ -212,32 +208,18 @@ Date: 2025-03-16
 Time: 15:00
 ```
 
-### Add a note to a session
-You can add notes to a session with the `add-note` command.
-```
-add-note INDEX n/NOTE
-```
-
-Example of usage:
-```
-add-note 1 n/Follow-up on medical assistance application
-```
-
-Expected outcome:
-```
-Added note to session:
-Date: 2025-03-15
-Time: 14:30
-Note: Follow-up on medical assistance application
-```
-
 ### List sessions
-You can view all sessions with the `list-sessions` command.
+You can view all sessions with the `list-sessions` command. Optionally, you can filter sessions by household.
 ```
 list-sessions [id/HOUSEHOLD_ID]
 ```
 
-Example of usage:
+Example of usage (all sessions):
+```
+list-sessions
+```
+
+Example of usage (household-specific):
 ```
 list-sessions id/H000003
 ```
@@ -250,27 +232,38 @@ Listed all sessions for household H000003:
 ```
 
 ## User Interface Navigation
-Em-Social features a dual-panel interface for efficient case management.
-
 ### Household panel
-The left panel displays all households. Click on a household to view its details and associated sessions.
+The household panel displays a list of all households. Click on a household to view its details and associated sessions.
 
 ### Session panel
-The right panel shows sessions for the selected household. This updates automatically when you select a different household.
+The session panel shows sessions for the selected household. Each session card displays the date, time, and any notes associated with the session.
 
 ### Command box
-Enter commands at the bottom of the window.
+Enter commands in the command box at the bottom of the application window. Press Enter to execute the command.
 
 ### Result display
-Above the command box, you'll see the results of your commands and any error messages.
+The result display shows the outcome of your most recent command, including success messages or error notifications.
 
-## Help
+## General Commands
+
+### Clear data
+You can clear all household and session data with the `clear` command.
+```
+clear
+```
+
+Expected outcome:
+```
+Address book has been cleared!
+```
+
+### Help
 You can view a summary of available commands with the `help` command.
 ```
 help
 ```
 
-## Exiting the program
+### Exiting the program
 You can exit Em-Social with the `exit` command.
 ```
 exit
@@ -288,11 +281,10 @@ Em-Social automatically saves data to a local file after each command. There is 
 | Delete household | `delete-household ID` | `delete-household H000001` |
 | List households | `list-households` | `list-households` |
 | Find households | `find-households KEYWORD [MORE_KEYWORDS]...` | `find-households Tan Lee` |
-| Tag household | `tag-household ID t/TAG [t/MORE_TAGS]...` | `tag-household H000003 t/elderly t/medical` |
 | Add session | `add-session id/HOUSEHOLD_ID d/DATE (YYYY-MM-DD) t/TIME (HH:MM)` | `add-session id/H000003 d/2025-03-15 t/14:30` |
-| Edit session | `edit-session INDEX d/DATE t/TIME` | `edit-session 1 d/2025-03-16 t/15:00` |
-| Delete session | `delete-session INDEX` | `delete-session 1` |
-| Add note to session | `add-note INDEX n/NOTE` | `add-note 1 n/Follow-up on medical assistance application` |
+| Edit session | `edit-session id/HOUSEHOLD_ID-SESSION_INDEX d/DATE t/TIME [n/NOTE]` | `edit-session id/H000003-1 d/2025-03-16 t/15:00 n/Follow-up note` |
+| Delete session | `delete-session id/HOUSEHOLD_ID-SESSION_INDEX` | `delete-session id/H000003-1` |
 | List sessions | `list-sessions [id/HOUSEHOLD_ID]` | `list-sessions id/H000003` |
+| Clear data | `clear` | `clear` |
 | Help | `help` | `help` |
 | Exit | `exit` | `exit` |

--- a/src/main/java/seedu/address/model/HouseholdBook.java
+++ b/src/main/java/seedu/address/model/HouseholdBook.java
@@ -1,8 +1,9 @@
 package seedu.address.model;
 
-import static java.util.Objects.requireNonNull;
-
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 
 import javafx.collections.FXCollections;
@@ -170,6 +171,20 @@ public class HouseholdBook implements ReadOnlyHouseholdBook {
     public boolean hasSession(Session session) {
         requireNonNull(session);
         return sessions.contains(session);
+    }
+
+    /**
+     * Returns an unmodifiable list of all sessions across all households.
+     */
+    public List<Session> getSessions() {
+        List<Session> allSessions = new ArrayList<>();
+        
+        // Collect sessions from all households
+        for (Household household : households) {
+            allSessions.addAll(household.getSessions());
+        }
+        
+        return Collections.unmodifiableList(allSessions);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyHouseholdBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyHouseholdBook.java
@@ -1,5 +1,7 @@
 package seedu.address.model;
 
+import java.util.List;
+
 import javafx.collections.ObservableList;
 import seedu.address.model.household.Household;
 import seedu.address.model.session.Session;
@@ -30,4 +32,9 @@ public interface ReadOnlyHouseholdBook {
      * Returns true if a session with the same identity as {@code session} exists in the household book.
      */
     boolean hasSession(Session session);
+
+    /**
+     * Returns an unmodifiable list of all sessions across all households.
+     */
+    List<Session> getSessions();
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -4,12 +4,16 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
+import java.util.UUID;
+import java.time.LocalDate;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.model.ReadOnlyHouseholdBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.household.Household;
+import seedu.address.model.session.Session;
 
 /**
  * Manages storage of HouseholdBook data in local storage.
@@ -60,7 +64,111 @@ public class StorageManager implements Storage {
     @Override
     public Optional<ReadOnlyHouseholdBook> readHouseholdBook(Path filePath) throws DataLoadingException {
         logger.fine("Attempting to read data from file: " + filePath);
-        return householdBookStorage.readHouseholdBook(filePath);
+        
+        Optional<ReadOnlyHouseholdBook> householdBookOptional = householdBookStorage.readHouseholdBook(filePath);
+        
+        // If we have data, validate it before returning
+        if (householdBookOptional.isPresent()) {
+            ReadOnlyHouseholdBook householdBook = householdBookOptional.get();
+            
+            // Validate household data
+            if (containsInvalidData(householdBook)) {
+                logger.warning("Data file at " + filePath + " contains invalid household or session data.");
+                return Optional.empty();
+            }
+        }
+        
+        return householdBookOptional;
+    }
+
+    /**
+     * Checks if the household book contains any invalid data that passed JSON parsing but has invalid fields
+     * @param householdBook The household book to check
+     * @return true if any invalid data is found, false otherwise
+     */
+    private boolean containsInvalidData(ReadOnlyHouseholdBook householdBook) {
+        // Check households for invalid data
+        for (Household household : householdBook.getHouseholdList()) {
+            if (!isValidHousehold(household)) {
+                logger.warning("Invalid household found: " + household.getName().toString());
+                return true;
+            }
+        }
+        
+        // Check sessions for invalid data
+        for (Session session : householdBook.getSessions()) {
+            if (!isValidSession(session)) {
+                logger.warning("Invalid session found for household: " + session.getHouseholdId().toString());
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * Validates a household entity beyond what JSON parsing does
+     */
+    private boolean isValidHousehold(Household household) {
+        try {
+            // Check ID format
+            if (!household.getId().toString().matches("H\\d{6}")) {
+                return false;
+            }
+            
+            // Check name (no special characters)
+            if (!household.getName().toString().matches("[\\p{Alnum}\\s,.'()-]+")) {
+                return false;
+            }
+            
+            // Check that address is not empty
+            if (household.getAddress().toString().trim().isEmpty()) {
+                return false;
+            }
+            
+            // Check contact is numeric
+            if (!household.getContact().toString().matches("\\d+")) {
+                return false;
+            }
+            
+            return true;
+        } catch (Exception e) {
+            // Any exception means invalid data
+            logger.warning("Exception during household validation: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Validates a session entity beyond what JSON parsing does
+     */
+    private boolean isValidSession(Session session) {
+        try {
+            // Ensure session ID is valid UUID format
+            UUID.fromString(session.getSessionId().toString());
+            
+            // Check household ID format
+            if (!session.getHouseholdId().toString().matches("H\\d{6}")) {
+                return false;
+            }
+            
+            // Validate date format
+            LocalDate.parse(session.getDate().toString());
+            
+            // Validate time format - hours should be 0-23, minutes 0-59
+            String[] timeParts = session.getTime().toString().split(":");
+            int hours = Integer.parseInt(timeParts[0]);
+            int minutes = Integer.parseInt(timeParts[1]);
+            if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+                return false;
+            }
+            
+            return true;
+        } catch (Exception e) {
+            // Any exception means invalid data
+            logger.warning("Exception during session validation: " + e.getMessage());
+            return false;
+        }
     }
 
     @Override

--- a/src/test/data/JsonHouseholdBookStorageTest/duplicateHouseholdsBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/duplicateHouseholdsBook.json
@@ -1,0 +1,16 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Tan Family",
+    "address": "123 Main St",
+    "contact": "98765432",
+    "tags": [ ]
+  }, {
+    "id": "H000002",
+    "name": "Tan Family",
+    "address": "Different Address",
+    "contact": "87654321",
+    "tags": [ ]
+  } ],
+  "sessions": [ ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/emptyAddressHouseholdBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/emptyAddressHouseholdBook.json
@@ -1,0 +1,9 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Tan Family",
+    "address": "",
+    "contact": "98765432",
+    "tags": [ ]
+  } ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/invalidContactHouseholdBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/invalidContactHouseholdBook.json
@@ -1,0 +1,9 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Tan Family",
+    "address": "123 Main St",
+    "contact": "9876abcd",
+    "tags": [ ]
+  } ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/invalidHouseholdBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/invalidHouseholdBook.json
@@ -1,0 +1,9 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Household with invalid name field: Tan@Family!",
+    "address": "123 Main St",
+    "contact": "98765432",
+    "tags": [ ]
+  } ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/invalidIdFormatHouseholdBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/invalidIdFormatHouseholdBook.json
@@ -1,0 +1,9 @@
+{
+  "households": [ {
+    "id": "InvalidID",
+    "name": "Tan Family",
+    "address": "123 Main St",
+    "contact": "98765432",
+    "tags": [ ]
+  } ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/invalidSessionBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/invalidSessionBook.json
@@ -1,0 +1,16 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Tan Family",
+    "address": "123 Main St",
+    "contact": "98765432",
+    "tags": [ ]
+  } ],
+  "sessions": [ {
+    "sessionId": "123456",
+    "householdId": "H000001",
+    "date": "invalid-date",
+    "time": "14:30",
+    "note": "Session with invalid date"
+  } ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/notJsonFormatHouseholdBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/notJsonFormatHouseholdBook.json
@@ -1,0 +1,1 @@
+not json format!

--- a/src/test/data/JsonHouseholdBookStorageTest/validHouseholdBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/validHouseholdBook.json
@@ -1,0 +1,16 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Tan Family",
+    "address": "123 Main St",
+    "contact": "98765432",
+    "tags": [ "elderly", "priority" ]
+  }, {
+    "id": "H000002",
+    "name": "Lee Family",
+    "address": "456 Oak Ave",
+    "contact": "87654321",
+    "tags": [ "children", "medical" ]
+  } ],
+  "sessions": [ ]
+}

--- a/src/test/data/JsonHouseholdBookStorageTest/validHouseholdWithSessionsBook.json
+++ b/src/test/data/JsonHouseholdBookStorageTest/validHouseholdWithSessionsBook.json
@@ -1,0 +1,22 @@
+{
+  "households": [ {
+    "id": "H000001",
+    "name": "Tan Family",
+    "address": "123 Main St",
+    "contact": "98765432",
+    "tags": [ "elderly", "priority" ]
+  } ],
+  "sessions": [ {
+    "sessionId": "317d2a70-9bb1-41cf-8bd2-5bc0f974cd5f",
+    "householdId": "H000001",
+    "date": "2025-03-15",
+    "time": "14:30",
+    "note": "Initial assessment visit"
+  }, {
+    "sessionId": "417d2a70-9bb1-41cf-8bd2-5bc0f974cd5e",
+    "householdId": "H000001",
+    "date": "2025-04-01",
+    "time": "10:00",
+    "note": "Follow-up on medical assistance application"
+  } ]
+}


### PR DESCRIPTION
This commit includes several important fixes and improvements:

1. Fix duplicate household detection:
   - Add isSameHousehold method to properly identify duplicates
   - Fix EditHouseholdCommand to prevent creating duplicate households
   - Update HouseholdBook.hasHousehold to ignore same ID when checking duplicates

2. Enhance session management:
   - Combine note functionality into EditSessionCommand
   - Refactor SessionCard.handleSessionUpdate to use enhanced command
   - Support adding/updating notes directly when editing sessions

3. Update user documentation:
   - Reflect command changes in UserGuide.md
   - Reorganize command sections for better clarity
   - Update command examples and expected outputs

These changes improve data integrity by preventing duplicate households and provide a more streamlined user experience for managing session notes.