### PR TITLE
Fix parser bug

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindHouseholdCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindHouseholdCommandParser.java
@@ -7,28 +7,26 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new FindHouseholdCommand object
+ * Parses input arguments and creates a new FindHouseholdCommand object.
  */
 public class FindHouseholdCommandParser implements Parser<FindHouseholdCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the FindHouseholdCommand
+     * Parses the given {@code String} of arguments in the context of FindHouseholdCommand
      * and returns a FindHouseholdCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform to the expected format.
      */
     public FindHouseholdCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
+
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindHouseholdCommand.MESSAGE_USAGE));
         }
-        if (!trimmedArgs.matches("[a-zA-Z0-9 ]+")) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindHouseholdCommand.MESSAGE_USAGE));
-        }
-        String[] keywords = trimmedArgs.split("\\s+");
+
+        // Pass the full trimmed input directly to FindHouseholdCommand
         try {
-            return new FindHouseholdCommand(String.join(" ", keywords));
+            return new FindHouseholdCommand(trimmedArgs);
         } catch (CommandException e) {
             throw new ParseException(e.getMessage());
         }

--- a/src/test/java/seedu/address/logic/parser/FindHouseholdCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindHouseholdCommandParserTest.java
@@ -76,16 +76,26 @@ public class FindHouseholdCommandParserTest {
     }
 
     @Test
-    public void parse_invalidInput_throwsParseException() {
+    public void parse_invalidInput_returnsFindHouseholdCommand() {
         // Arrange
         String userInput = "!!!";
+        FindHouseholdCommand expectedCommand = null;
+        try {
+            expectedCommand = new FindHouseholdCommand("!!!");
+        } catch (CommandException e) {
+            throw new RuntimeException(e);
+        }
 
-        // Act & Assert
-        ParseException thrown = assertThrows(ParseException.class, () -> {
-            parser.parse(userInput);
-        });
-        assertEquals(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindHouseholdCommand.MESSAGE_USAGE),
-                thrown.getMessage());
+        // Act
+        FindHouseholdCommand result = null;
+        try {
+            result = parser.parse(userInput);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Assert
+        assertEquals(expectedCommand, result);
     }
 
     @Test


### PR DESCRIPTION
Fix a bug in FindHouseholdCommandParser where quotations
were stripped.

This effectively removed the searching for key phrases via
"" functionality.

This has been fixed and restored.