### PR TITLE
Fix EditHouseholdCommand and UG

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditHouseholdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditHouseholdCommand.java
@@ -46,7 +46,7 @@ public class EditHouseholdCommand extends Command {
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_HOUSEHOLD_NOT_FOUND = "No household found with ID: %1$s";
     public static final String MESSAGE_DUPLICATE_HOUSEHOLD = "This household would be a duplicate"
-            + "of an existing household.";
+            + " of an existing household.";
 
     private final HouseholdId householdId;
     private final EditHouseholdDescriptor editHouseholdDescriptor;


### PR DESCRIPTION
1. Fixed "duplicateof" typo in EditHouseholdCommand
2. Fixed list-command system output in the User Guide
3. Fixed image not resolving to an actual png file.
4. Added screenshots for FindHouseholdCommand