### PR TITLE
Fix visibility scope issue in JSON serialization classes

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedHousehold.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedHousehold.java
@@ -20,7 +20,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Jackson-friendly version of {@link Household}.
  */
-class JsonAdaptedHousehold {
+public class JsonAdaptedHousehold {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Household's %s field is missing!";
 

--- a/src/main/java/seedu/address/storage/JsonSerializableHouseholdBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableHouseholdBook.java
@@ -34,8 +34,8 @@ public class JsonSerializableHouseholdBook {
     @JsonCreator
     public JsonSerializableHouseholdBook(@JsonProperty("households") List<JsonAdaptedHousehold> households,
                                          @JsonProperty("sessions") List<JsonAdaptedSession> sessions) {
-        this.households.addAll(households);
-        this.sessions.addAll(sessions);
+        this.households.addAll(households == null ? new ArrayList<>() : households);
+        this.sessions.addAll(sessions == null ? new ArrayList<>() : sessions);
     }
 
     /**


### PR DESCRIPTION
- Added null checks in JsonSerializableHouseholdBook constructor for robustness
- Ensured JsonAdaptedHousehold class has proper public visibility modifier
- Fixed class visibility scope violation that was causing compiler errors
- Improved defensive programming in JSON deserialization process